### PR TITLE
Value request base for installable objects

### DIFF
--- a/src/Simplic.Package.CLI/Program.cs
+++ b/src/Simplic.Package.CLI/Program.cs
@@ -70,6 +70,8 @@ namespace Simplic.Package.CLI
             var path = "";
             var connectionString = "dbn=PackageTest;server=PackageTest;uid=admin;pwd=school";
 
+            var testMode = false;
+
             var optionSet = new OptionSet()
             {
                 { "m|mkconfig=", "Creates a package.json file with given Name.", v =>  {create = true; name = v; } },
@@ -81,7 +83,11 @@ namespace Simplic.Package.CLI
                 { "c|connection=", "The database connection string.", v =>  {connectionString = v; } },
                 { "h|help",  "Shows help", v => showHelp = true },
                 { "v|verbosity=", "Sets the Loglevel.\n Error: 0, Warning: 1, Info: 2, Debug: 3. Default: 0",
-                    v => verbosity = (LogLevel)Int32.Parse(v) }
+                    v => verbosity = (LogLevel)Int32.Parse(v) },
+                { "test", 
+                    "Starts the application in test mode, this should just be set in automated tests." +
+                    " This will not test wether the package is installable, this will disable some features " +
+                    "that require user intput for testing purposes", v => testMode = true }
             };
 
             if (!args.Any())
@@ -112,6 +118,11 @@ namespace Simplic.Package.CLI
                 ShowHelp(optionSet);
                 return 0;
             }
+
+            if (testMode)
+                ApplicationSettings.ApplicationMode = ApplicationMode.Test;
+            else
+                ApplicationSettings.ApplicationMode = ApplicationMode.CLI;
 
             #region Register types
             var container = new UnityContainer();

--- a/src/Simplic.Package.Service/InstallService.cs
+++ b/src/Simplic.Package.Service/InstallService.cs
@@ -104,7 +104,7 @@ namespace Simplic.Package.Service
                         }
                     }
                 }
-                catch (DependencyMissingException)
+                catch (ResolutionFailedException)
                 {
                     // pass (no value request service registered).
                 }

--- a/src/Simplic.Package.Service/InstallService.cs
+++ b/src/Simplic.Package.Service/InstallService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity;

--- a/src/Simplic.Package.Service/Simplic.Package.Service.csproj
+++ b/src/Simplic.Package.Service/Simplic.Package.Service.csproj
@@ -72,6 +72,9 @@
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="Unity">
+      <Version>5.11.10</Version>
+    </PackageReference>
     <PackageReference Include="Unity.Abstractions">
       <Version>5.11.7</Version>
     </PackageReference>

--- a/src/Simplic.Package.Service/Simplic.Package.Service.csproj
+++ b/src/Simplic.Package.Service/Simplic.Package.Service.csproj
@@ -72,9 +72,6 @@
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Unity">
-      <Version>5.11.10</Version>
-    </PackageReference>
     <PackageReference Include="Unity.Abstractions">
       <Version>5.11.7</Version>
     </PackageReference>

--- a/src/Simplic.Package/Enum/ApplicationMode.cs
+++ b/src/Simplic.Package/Enum/ApplicationMode.cs
@@ -1,0 +1,25 @@
+﻿namespace Simplic.Package
+{
+    /// <summary>
+    /// Represents the mode in which the application is opened.
+    /// Should be relevant for the IRequestValueService.
+    /// </summary>
+    public enum ApplicationMode
+    {
+        /// <summary>
+        /// The application is opened as CLI application.
+        /// </summary>
+        CLI = 0,
+
+        /// <summary>
+        /// The application is opened as UI application.
+        /// </summary>
+        UI = 1,
+
+        /// <summary>
+        /// The application is opened as in test mode.
+        /// This should only be set in automated tests where no user interaction is possible.
+        /// </summary>
+        Test = 99
+    }
+}

--- a/src/Simplic.Package/Interface/Object/IRequestValueService.cs
+++ b/src/Simplic.Package/Interface/Object/IRequestValueService.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+
+namespace Simplic.Package
+{
+    /// <summary>
+    /// Interface to request a value from the user.
+    /// <para>
+    /// Target is that we will be able to request data from the user.
+    /// </para>
+    /// Problem with a simple Console.ReadLine are possible automated tests and a later implemented UI.
+    /// <para>
+    /// Also I would like to call the RequestValueService once for each object type and not for each object
+    /// since it could get pretty anoying for the user when he has to fill 20 windows with 1 line instead of 1
+    /// window with 20 lines.
+    /// </para>
+    /// </summary>
+    public interface IRequestValueService
+    {
+        /// <summary>
+        /// Requests the value for a list of installable objects.
+        /// </summary>
+        /// <param name="installableObjects">A list of installable objects of 1 type.</param>
+        /// <returns>Wether the request was successfull.</returns>
+        RequestValueResult RequestValue(IList<InstallableObject> installableObjects);
+    }
+}

--- a/src/Simplic.Package/Model/ApplicationSettings.cs
+++ b/src/Simplic.Package/Model/ApplicationSettings.cs
@@ -1,0 +1,16 @@
+﻿namespace Simplic.Package
+{
+    /// <summary>
+    /// Applicaiton relevant information for e.g. the application mode.
+    /// </summary>
+    public static class ApplicationSettings
+    {
+        /// <summary>
+        /// Gets or sets the application mode.
+        /// <para>
+        /// This one should not be changed other than on startup.
+        /// </para>
+        /// </summary>
+        public static ApplicationMode ApplicationMode { get; set; }
+    }
+}

--- a/src/Simplic.Package/Model/RequestValueResult.cs
+++ b/src/Simplic.Package/Model/RequestValueResult.cs
@@ -1,0 +1,13 @@
+﻿namespace Simplic.Package
+{
+    /// <summary>
+    /// Represents the result of a method that reqeusts a value.
+    /// </summary>
+    public class RequestValueResult
+    {
+        /// <summary>
+        /// Gets or sets wether the value request was successfull.
+        /// </summary>
+        public bool Success { get; set; }
+    }
+}

--- a/src/Simplic.Package/Simplic.Package.csproj
+++ b/src/Simplic.Package/Simplic.Package.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\PackageExtensionAttribute.cs" />
+    <Compile Include="Enum\ApplicationMode.cs" />
     <Compile Include="Exception\ExistingPackageException.cs" />
     <Compile Include="Exception\InvalidContentException.cs" />
     <Compile Include="Exception\MissingExtensionException.cs" />

--- a/src/Simplic.Package/Simplic.Package.csproj
+++ b/src/Simplic.Package/Simplic.Package.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Interface\Core\ILogService.cs" />
     <Compile Include="Interface\Core\IMigrationRepository.cs" />
     <Compile Include="Interface\Core\IMigrationService.cs" />
+    <Compile Include="Interface\Object\IRequestValueService.cs" />
     <Compile Include="Interface\Package\IValidatePackageConfigurationService.cs" />
     <Compile Include="Model\LogResult\InitializePackageSystemResult.cs" />
     <Compile Include="Interface\Core\IInitializePackageSystemRepository.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="Model\PackObjectResult.cs" />
     <Compile Include="Model\ExtractArchiveEntryResult.cs" />
     <Compile Include="Model\Payload.cs" />
+    <Compile Include="Model\RequestValueResult.cs" />
     <Compile Include="PackageFormatVersion\PackageFormatVersion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Model\LogResult\ValidateObjectResult.cs" />

--- a/src/Simplic.Package/Simplic.Package.csproj
+++ b/src/Simplic.Package/Simplic.Package.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Interface\Core\IMigrationService.cs" />
     <Compile Include="Interface\Object\IRequestValueService.cs" />
     <Compile Include="Interface\Package\IValidatePackageConfigurationService.cs" />
+    <Compile Include="Model\ApplicationSettings.cs" />
     <Compile Include="Model\LogResult\InitializePackageSystemResult.cs" />
     <Compile Include="Interface\Core\IInitializePackageSystemRepository.cs" />
     <Compile Include="Model\LogResult\LogResult.cs" />


### PR DESCRIPTION
This contains the base implementation to enable the request of values during the insallation process.
It should only request the values for all installable objects of 1 type at once instead of requesting the value of all results.
This should make handling the ui way more comfortable for the user.