### PR TITLE
Add python scripts as executable package objects. (part of ~770)

### DIFF
--- a/src/Simplic.Package.CLI/Program.cs
+++ b/src/Simplic.Package.CLI/Program.cs
@@ -48,6 +48,7 @@ using Simplic.Package.Ribbon;
 using Unity.ServiceLocation;
 using Simplic.Package.Configuration;
 using System.Diagnostics;
+using Simplic.Package.IronPythonScript;
 
 namespace Simplic.Package.CLI
 {
@@ -55,6 +56,8 @@ namespace Simplic.Package.CLI
     {
         public static async Task<int> Main(string[] args)
         {
+            Debugger.Launch();
+
             var showHelp = false;
             var verbosity = LogLevel.Debug;
 
@@ -232,6 +235,10 @@ namespace Simplic.Package.CLI
             container.RegisterType<IObjectRepository, StackRegisterRepository>("stackRegister");
             container.RegisterType<IPackObjectService, PackStackRegisterService>("stackRegister");
             container.RegisterType<IUnpackObjectService, UnpackStackRegisterService>("stackRegister");
+
+            container.RegisterType<IInstallObjectService, InstallScriptService>("script");
+            container.RegisterType<IPackObjectService, PackScriptService>("script");
+            container.RegisterType<IUnpackObjectService, UnpackScriptService>("script");
 
             container.RegisterType<ISqlService, SqlService>();
             container.RegisterType<ISqlColumnService, SqlColumnService>();

--- a/src/Simplic.Package.CLI/Simplic.Package.CLI.csproj
+++ b/src/Simplic.Package.CLI/Simplic.Package.CLI.csproj
@@ -110,6 +110,10 @@
       <Project>{efbf2689-c964-48a0-ad3e-bf7373e3ce3e}</Project>
       <Name>Simplic.Package.Icon</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Simplic.Package.IronPythonScript\Simplic.Package.IronPythonScript.csproj">
+      <Project>{6eb2673b-73c1-4c52-bdf3-db6994364cef}</Project>
+      <Name>Simplic.Package.IronPythonScript</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Simplic.Package.Itembox\Simplic.Package.ItemBox.csproj">
       <Project>{4eae3b26-1813-42cd-86a5-6df5e2c1048d}</Project>
       <Name>Simplic.Package.ItemBox</Name>

--- a/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
@@ -6,6 +6,7 @@ namespace Simplic.Package.IronPythonScript
 {
     /// <summary>
     /// Service to install an iron python script.
+    /// Or in this case execute, not install.
     /// </summary>
     public class InstallScriptService : IInstallObjectService
     {

--- a/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
@@ -1,5 +1,4 @@
-﻿using Simplic.Framework.Core;
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -17,9 +16,9 @@ namespace Simplic.Package.IronPythonScript
             {
                 if (installableObject.Content is IronPythonScript script)
                 {
-                    GlobalDlrHost.Host.DefaultScope.Execute(script.Script);
+                    PackagePythonDlrHost.Host.DefaultScope.Execute(script.Script);
                     var classname = Path.GetFileName(installableObject.Target);
-                    var classInstance = GlobalDlrHost.Host.DefaultScope.CreateClassInstance(classname);
+                    var classInstance = PackagePythonDlrHost.Host.DefaultScope.CreateClassInstance(classname);
 
                     classInstance.Instance.execute();
                 }

--- a/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
@@ -1,0 +1,40 @@
+﻿using Simplic.Framework.Core;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Service to install an iron python script.
+    /// </summary>
+    public class InstallScriptService : IInstallObjectService
+    {
+        /// <inheritdoc/>
+        public Task<InstallObjectResult> InstallObject(InstallableObject installableObject)
+        {
+            try
+            {
+                if (installableObject.Content is IronPythonScript script)
+                {
+                    GlobalDlrHost.Host.DefaultScope.Execute(script.Script);
+                    var classname = Path.GetFileName(installableObject.Target);
+                    var classInstance = GlobalDlrHost.Host.DefaultScope.CreateClassInstance(classname);
+
+                    classInstance.Instance.Execute();
+                }
+                return Task.FromResult(new InstallObjectResult { Success = true });
+            }
+            catch
+            {
+                return Task.FromResult(new InstallObjectResult { Success = false });
+            }
+        }
+
+        /// <inheritdoc/>
+        public Task<UninstallObjectResult> UninstallObject(InstallableObject installableObject)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
@@ -21,7 +21,7 @@ namespace Simplic.Package.IronPythonScript
                     var classname = Path.GetFileName(installableObject.Target);
                     var classInstance = GlobalDlrHost.Host.DefaultScope.CreateClassInstance(classname);
 
-                    classInstance.Instance.Execute();
+                    classInstance.Instance.execute();
                 }
                 return Task.FromResult(new InstallObjectResult { Success = true });
             }

--- a/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/InstallScriptService.cs
@@ -10,8 +10,15 @@ namespace Simplic.Package.IronPythonScript
     /// </summary>
     public class InstallScriptService : IInstallObjectService
     {
+        private readonly ILogService logService;
+
+        public InstallScriptService(ILogService logService)
+        {
+            this.logService = logService;
+        }
+
         /// <inheritdoc/>
-        public Task<InstallObjectResult> InstallObject(InstallableObject installableObject)
+        public async Task<InstallObjectResult> InstallObject(InstallableObject installableObject)
         {
             try
             {
@@ -23,11 +30,12 @@ namespace Simplic.Package.IronPythonScript
 
                     classInstance.Instance.execute();
                 }
-                return Task.FromResult(new InstallObjectResult { Success = true });
+                return new InstallObjectResult { Success = true };
             }
-            catch
+            catch (Exception ex)
             {
-                return Task.FromResult(new InstallObjectResult { Success = false });
+                await logService.WriteAsync("Error during script execution", LogLevel.Error, ex);
+                return new InstallObjectResult { Success = false };
             }
         }
 

--- a/src/Simplic.Package.IronPythonScript/IronPythonScript.cs
+++ b/src/Simplic.Package.IronPythonScript/IronPythonScript.cs
@@ -1,0 +1,13 @@
+﻿namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Represents an iron python script with its content.
+    /// </summary>
+    public class IronPythonScript : IContent
+    {
+        /// <summary>
+        /// Gets or sets the script content.
+        /// </summary>
+        public string Script { get; set; }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/Modules/DependencyInjection.cs
+++ b/src/Simplic.Package.IronPythonScript/Modules/DependencyInjection.cs
@@ -1,0 +1,61 @@
+﻿using IronPython.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unity;
+
+namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Python api module path root (~import simplic)
+    /// </summary>
+    public static partial class PythonApiModule
+    {
+        /// <summary>
+        /// Dependency injection module for python
+        /// </summary>
+        [PythonType("DependencyInjection")]
+        public static class DependencyInjection
+        {
+            /// <summary>
+            /// API-Doc string. Can be used like this: simplic.'ModuleName'.__doc__
+            /// </summary>
+            public const string __doc__ = @"Module which provides functions to use simplic dependency injection.";
+
+            /// <summary>
+            /// Get instance of a unity service
+            /// </summary>
+            /// <param name="type">Interface type</param>
+            /// <returns>Instance of an unity service</returns>
+            public static object resolve(IronPython.Runtime.Types.PythonType type)
+            {
+                return CommonServiceLocator.ServiceLocator.Current.GetInstance(type.__clrtype__());
+            }
+
+            /// <summary>
+            /// Get instance of a unity service
+            /// </summary>
+            /// <param name="type">Interface type</param>
+            /// <param name="key">Optional key</param>
+            /// <returns>Instance of an unity service</returns>
+            public static object resolve_with_key(IronPython.Runtime.Types.PythonType type, string key)
+            {
+                return CommonServiceLocator.ServiceLocator.Current.GetInstance(type.__clrtype__(), key);
+            }
+
+            /// <summary>
+            /// Register instance
+            /// </summary>
+            /// <param name="type">Interface type</param>
+            /// <param name="key">Key</param>
+            /// <param name="instance">Python class instance</param>
+            public static void register_instance(IronPython.Runtime.Types.PythonType type, string key, object instance)
+            {
+                var unity = CommonServiceLocator.ServiceLocator.Current.GetInstance<IUnityContainer>();
+                unity.RegisterInstance(type.__clrtype__(), key, instance);
+            }
+        }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/Modules/Sql.cs
+++ b/src/Simplic.Package.IronPythonScript/Modules/Sql.cs
@@ -20,7 +20,7 @@ namespace Simplic.Package.IronPythonScript
             {
                 sqlService = CommonServiceLocator.ServiceLocator.Current.GetInstance<ISqlService>();
             }
-
+            
             public static IList<object> execute(string query, IList<object> parameter)
             {
                 return sqlService.OpenConnection(connection =>

--- a/src/Simplic.Package.IronPythonScript/Modules/Sql.cs
+++ b/src/Simplic.Package.IronPythonScript/Modules/Sql.cs
@@ -1,0 +1,33 @@
+﻿using Dapper;
+using IronPython.Runtime;
+using Simplic.Sql;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Simplic.Package.IronPythonScript
+{
+    public static partial class PythonApiModule
+    {
+        [PythonType("Sql")]
+        public static class Sql
+        {
+            private static ISqlService sqlService;
+
+            static Sql()
+            {
+                sqlService = CommonServiceLocator.ServiceLocator.Current.GetInstance<ISqlService>();
+            }
+
+            public static IList<object> execute(string query, IList<object> parameter)
+            {
+                return sqlService.OpenConnection(connection =>
+                {
+                    return connection.Query(query, parameter).ToList();
+                });
+            }
+        }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/PackScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/PackScriptService.cs
@@ -1,0 +1,17 @@
+﻿namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Service to pack scripts.
+    /// </summary>
+    public class PackScriptService : PackObjectServiceBase
+    {
+        /// <summary>
+        /// Initializes a new instace of <see cref="PackScriptService"/>.
+        /// </summary>
+        /// <param name="fileService"></param>
+        public PackScriptService(IFileService fileService) : base(fileService)
+        {
+
+        }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/PackagePythonDlrHost.cs
+++ b/src/Simplic.Package.IronPythonScript/PackagePythonDlrHost.cs
@@ -1,4 +1,6 @@
 ﻿using Simplic.Dlr;
+using System;
+using System.IO;
 
 namespace Simplic.Package.IronPythonScript
 {
@@ -22,6 +24,11 @@ namespace Simplic.Package.IronPythonScript
         {
             Language = new IronPythonLanguage();
             Host = new DlrHost<IronPythonLanguage>(Language);
+
+            var studioPath = Environment.GetEnvironmentVariable("Simplic Studio");
+            var path = Path.Combine(studioPath, "Scripts", "Python");
+
+            Host.AddSearchPath(path);
         }
 
         /// <summary>

--- a/src/Simplic.Package.IronPythonScript/PackagePythonDlrHost.cs
+++ b/src/Simplic.Package.IronPythonScript/PackagePythonDlrHost.cs
@@ -1,0 +1,46 @@
+﻿using Simplic.Dlr;
+
+namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Dlr host for the package system.
+    /// </summary>
+    public static class PackagePythonDlrHost
+    {
+        /// <summary>
+        /// Initializes the dlr host.
+        /// </summary>
+        static PackagePythonDlrHost()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Initialize the language and the host.
+        /// </summary>
+        private static void Initialize()
+        {
+            Language = new IronPythonLanguage();
+            Host = new DlrHost<IronPythonLanguage>(Language);
+        }
+
+        /// <summary>
+        /// Reset script scope. Should only be used if you really know what it does.
+        /// It creates a new scope and make the old one not available any longer.
+        /// </summary>
+        public static void ResetScriptScope()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Accessing host context
+        /// </summary>
+        public static DlrHost<IronPythonLanguage> Host { get; private set; }
+
+        /// <summary>
+        /// Accessing language context
+        /// </summary>
+        public static IronPythonLanguage Language { get; private set; }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/Properties/AssemblyInfo.cs
+++ b/src/Simplic.Package.IronPythonScript/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Simplic.Package.IronPythonScript")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Simplic.Package.IronPythonScript")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6eb2673b-73c1-4c52-bdf3-db6994364cef")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Simplic.Package.IronPythonScript/PythonApiModule.cs
+++ b/src/Simplic.Package.IronPythonScript/PythonApiModule.cs
@@ -1,0 +1,13 @@
+﻿using IronPython.Runtime;
+
+[assembly: PythonModule("simplic_package", typeof(Simplic.Package.IronPythonScript.PythonApiModule))]
+namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Simplic package api module base.
+    /// </summary>
+    public static partial class PythonApiModule
+    {
+        public const string __doc__ = "The python module is part of the simplic package python api.";
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="InstallScriptService.cs" />
     <Compile Include="IronPythonScript.cs" />
+    <Compile Include="PackScriptService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -61,9 +61,6 @@
     <PackageReference Include="Simplic.Dlr">
       <Version>1.4.20.322</Version>
     </PackageReference>
-    <PackageReference Include="Simplic.Framework.Base">
-      <Version>8.1.22.101</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -43,9 +43,12 @@
   <ItemGroup>
     <Compile Include="InstallScriptService.cs" />
     <Compile Include="IronPythonScript.cs" />
+    <Compile Include="Modules\DependencyInjection.cs" />
+    <Compile Include="Modules\Sql.cs" />
     <Compile Include="PackagePythonDlrHost.cs" />
     <Compile Include="PackScriptService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PythonApiModule.cs" />
     <Compile Include="UnpackScriptService.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -58,12 +61,25 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CommonServiceLocator">
+      <Version>2.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Dapper">
+      <Version>2.0.123</Version>
+    </PackageReference>
     <PackageReference Include="IronPython">
       <Version>2.7.9</Version>
     </PackageReference>
     <PackageReference Include="Simplic.Dlr">
       <Version>1.4.20.322</Version>
     </PackageReference>
+    <PackageReference Include="Simplic.Sql">
+      <Version>6.3.121.1212</Version>
+    </PackageReference>
+    <PackageReference Include="Unity.Abstractions">
+      <Version>5.11.7</Version>
+    </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Simplic.Package.IronPythonScript</RootNamespace>
+    <AssemblyName>Simplic.Package.IronPythonScript</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="IronPython, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.Modules, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.SQLite, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.Wpf, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.Wpf.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Dynamic, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Dynamic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Scripting, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Scripting.AspNet, Version=1.1.1.21, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.AspNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Scripting.Metadata, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="Simplic.Dlr, Version=1.4.20.322, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Simplic.Dlr.1.4.20.322\lib\net48\Simplic.Dlr.dll</HintPath>
+    </Reference>
+    <Reference Include="Simplic.Framework.Base, Version=8.1.22.101, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Simplic.Framework.Base.8.1.22.101\lib\net48\Simplic.Framework.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="InstallScriptService.cs" />
+    <Compile Include="IronPythonScript.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Simplic.Package\Simplic.Package.csproj">
+      <Project>{0aca9764-a25d-4517-b64e-95645674666b}</Project>
+      <Name>Simplic.Package</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -58,6 +58,9 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="IronPython">
+      <Version>2.7.9</Version>
+    </PackageReference>
     <PackageReference Include="Simplic.Dlr">
       <Version>1.4.20.322</Version>
     </PackageReference>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -31,36 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="IronPython, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.dll</HintPath>
-    </Reference>
-    <Reference Include="IronPython.Modules, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.Modules.dll</HintPath>
-    </Reference>
-    <Reference Include="IronPython.SQLite, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.SQLite.dll</HintPath>
-    </Reference>
-    <Reference Include="IronPython.Wpf, Version=2.7.7.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\IronPython.2.7.7\lib\Net45\IronPython.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Dynamic, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Dynamic.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Scripting, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.AspNet, Version=1.1.1.21, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.AspNet.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Scripting.Metadata, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamicLanguageRuntime.1.1.2\lib\Net45\Microsoft.Scripting.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="Simplic.Dlr, Version=1.4.20.322, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Simplic.Dlr.1.4.20.322\lib\net48\Simplic.Dlr.dll</HintPath>
-    </Reference>
-    <Reference Include="Simplic.Framework.Base, Version=8.1.22.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Simplic.Framework.Base.8.1.22.101\lib\net48\Simplic.Framework.Base.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -83,7 +53,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Simplic.Dlr">
+      <Version>1.4.20.322</Version>
+    </PackageReference>
+    <PackageReference Include="Simplic.Framework.Base">
+      <Version>8.1.22.101</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="InstallScriptService.cs" />
     <Compile Include="IronPythonScript.cs" />
+    <Compile Include="PackagePythonDlrHost.cs" />
     <Compile Include="PackScriptService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnpackScriptService.cs" />

--- a/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
+++ b/src/Simplic.Package.IronPythonScript/Simplic.Package.IronPythonScript.csproj
@@ -45,6 +45,7 @@
     <Compile Include="IronPythonScript.cs" />
     <Compile Include="PackScriptService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnpackScriptService.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Simplic.Package\Simplic.Package.csproj">

--- a/src/Simplic.Package.IronPythonScript/UnpackScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/UnpackScriptService.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+
+namespace Simplic.Package.IronPythonScript
+{
+    /// <summary>
+    /// Service to unpack script services
+    /// </summary>
+    public class UnpackScriptService : IUnpackObjectService
+    {
+        /// <inheritdoc/>
+        public Task<UnpackObjectResult> UnpackObject(ExtractArchiveEntryResult extractArchiveEntryResult)
+        {
+            var installableObject = new InstallableObject
+            {
+                Content = new IronPythonScript
+                {
+                    Script = extractArchiveEntryResult.Data.ToString()
+                },
+                Target = extractArchiveEntryResult.Location,
+                Mode = extractArchiveEntryResult.Mode
+            };
+
+            return Task.FromResult(new UnpackObjectResult
+            {
+                InstallableObject = installableObject,
+                Message = $"Unpacked repository at {extractArchiveEntryResult.Location}",
+                LogLevel = LogLevel.Info
+            });
+        }
+    }
+}

--- a/src/Simplic.Package.IronPythonScript/UnpackScriptService.cs
+++ b/src/Simplic.Package.IronPythonScript/UnpackScriptService.cs
@@ -14,7 +14,7 @@ namespace Simplic.Package.IronPythonScript
             {
                 Content = new IronPythonScript
                 {
-                    Script = extractArchiveEntryResult.Data.ToString()
+                    Script = System.Text.Encoding.Default.GetString(extractArchiveEntryResult.Data)
                 },
                 Target = extractArchiveEntryResult.Location,
                 Mode = extractArchiveEntryResult.Mode

--- a/src/Simplic.Package.IronPythonScript/app.config
+++ b/src/Simplic.Package.IronPythonScript/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Scripting" publicKeyToken="7f709c5b713576e1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.22" newVersion="1.1.2.22" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="IronPython" publicKeyToken="7f709c5b713576e1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.7.0" newVersion="2.7.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Dynamic" publicKeyToken="7f709c5b713576e1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.22" newVersion="1.1.2.22" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Simplic.Package.IronPythonScript/packages.config
+++ b/src/Simplic.Package.IronPythonScript/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DynamicLanguageRuntime" version="1.1.2" targetFramework="net48" />
+  <package id="IronPython" version="2.7.7" targetFramework="net48" />
+  <package id="Simplic.Dlr" version="1.4.20.322" targetFramework="net48" />
+  <package id="Simplic.Framework.Base" version="8.1.22.101" targetFramework="net48" />
+</packages>

--- a/src/Simplic.Package.IronPythonScript/packages.config
+++ b/src/Simplic.Package.IronPythonScript/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DynamicLanguageRuntime" version="1.1.2" targetFramework="net48" />
-  <package id="IronPython" version="2.7.7" targetFramework="net48" />
-  <package id="Simplic.Dlr" version="1.4.20.322" targetFramework="net48" />
-  <package id="Simplic.Framework.Base" version="8.1.22.101" targetFramework="net48" />
-</packages>

--- a/src/Simplic.Package.Service/InstallService.cs
+++ b/src/Simplic.Package.Service/InstallService.cs
@@ -75,9 +75,7 @@ namespace Simplic.Package.Service
             // Load extensions.
             if (package.Extensions.Any())
             {
-                await logService.WriteAsync("Loading extensions...", LogLevel.Info);
-                extensionService.LoadExtensions(package.Extensions);
-
+                //extensions should be loaded during unpack.
                 if (package.Extensions.Any(x => !ExtensionHelper.LoadedExtensions.Contains(x)))
                 {
                     await logService.WriteAsync("Could not load all extensions", LogLevel.Error);

--- a/src/simplic-package.sln
+++ b/src/simplic-package.sln
@@ -161,6 +161,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplic.Package.Test.Extens
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplic.Package.Configuration", "Simplic.Package.Configuration\Simplic.Package.Configuration.csproj", "{981FF658-0F11-463E-A283-8459328281A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplic.Package.IronPythonScript", "Simplic.Package.IronPythonScript\Simplic.Package.IronPythonScript.csproj", "{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -271,6 +273,10 @@ Global
 		{981FF658-0F11-463E-A283-8459328281A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{981FF658-0F11-463E-A283-8459328281A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{981FF658-0F11-463E-A283-8459328281A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EB2673B-73C1-4C52-BDF3-DB6994364CEF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -315,6 +321,7 @@ Global
 		{694EC2CB-4973-4BFB-B45C-74CAB326EDEF} = {A157A560-3710-4C79-9A0F-EFA8EC55366C}
 		{B528F0D8-D0A8-4C46-9416-F812D292468F} = {FEC87CDA-841F-43DB-882C-7F40DF7A8B5D}
 		{981FF658-0F11-463E-A283-8459328281A0} = {FEC87CDA-841F-43DB-882C-7F40DF7A8B5D}
+		{6EB2673B-73C1-4C52-BDF3-DB6994364CEF} = {FEC87CDA-841F-43DB-882C-7F40DF7A8B5D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4EA82266-D86E-4D97-B0C6-41D6E7D8A584}


### PR DESCRIPTION
For this I added a new DLR host since the global dlr host uses some libarys I don't want to add to the package system and also he adds paths that might not be accessible from the package system, like OldCodeBehind paths.